### PR TITLE
Timezone bug

### DIFF
--- a/apps/artemis-web/components/system-configuration/system-configuration.tsx
+++ b/apps/artemis-web/components/system-configuration/system-configuration.tsx
@@ -172,11 +172,9 @@ const SystemConfigurationComponent = (props) => {
                     )
                     : 'Never'}
                 </span>
-                <span style={{ float: 'right' }}>
-                  Times are shown in your local time zone GMT
-                  {new Date().getTimezoneOffset() < 0 ? '+' : ''}
-                  {-(new Date().getTimezoneOffset() / 60)} (
-                  {Intl.DateTimeFormat().resolvedOptions().timeZone}).
+                <span style={{ float: 'right', marginTop: '15px' }}>
+                  Times are shown in your local time zone{' '}
+                  <b>GMT{new Date().getTimezoneOffset() > 0 ? '-' : '+'}{Math.abs(new Date().getTimezoneOffset() / 60)} ({Intl.DateTimeFormat().resolvedOptions().timeZone}).</b>
                 </span>
               </div>
             </div>

--- a/apps/artemis-web/pages/dashboard.tsx
+++ b/apps/artemis-web/pages/dashboard.tsx
@@ -89,8 +89,8 @@ const DashboardPage = (props: any) => {
                       (
                       {user &&
                         new Date(user.lastLogin).toLocaleDateString() +
-                          ' ' +
-                          new Date(user.lastLogin).toLocaleTimeString()}
+                        ' ' +
+                        new Date(user.lastLogin).toLocaleTimeString()}
                       )
                     </b>
                     . You are {user && user.role}.
@@ -112,7 +112,7 @@ const DashboardPage = (props: any) => {
                 </div>
                 <span style={{ float: 'right', marginTop: '15px' }}>
                   Times are shown in your local time zone{' '}
-                  <b>GMT+2 (Europe/Athens).</b>
+                  <b>GMT{new Date().getTimezoneOffset() > 0 ? '-' : '+'}{Math.abs(new Date().getTimezoneOffset() / 60)} ({Intl.DateTimeFormat().resolvedOptions().timeZone}).</b>
                 </span>
               </div>
               {!matches.pc && (

--- a/apps/artemis-web/pages/hijacks.tsx
+++ b/apps/artemis-web/pages/hijacks.tsx
@@ -91,7 +91,7 @@ const HijacksPage = (props) => {
       {user && (
         <div
           className="container overview col-lg-12"
-          // style={{ paddingTop: '120px' }}
+        // style={{ paddingTop: '120px' }}
         >
           <div className="row">
             <div className="col-lg-1" />
@@ -538,9 +538,9 @@ const HijacksPage = (props) => {
                   className="card-header"
                   style={{ backgroundColor: 'white' }}
                 >
-                  <span style={{ float: 'right' }}>
+                  <span style={{ float: 'right', marginTop: '15px' }}>
                     Times are shown in your local time zone{' '}
-                    <b>GMT+2 (Europe/Athens).</b>
+                    <b>GMT{new Date().getTimezoneOffset() > 0 ? '-' : '+'}{Math.abs(new Date().getTimezoneOffset() / 60)} ({Intl.DateTimeFormat().resolvedOptions().timeZone}).</b>
                   </span>
                 </div>
               </div>

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -33,7 +33,7 @@ services:
     depends_on:
       - mongodb
   mongodb:
-    image: mongo:latest
+    image: mongo:4.4.6-bionic
     container_name: mongodb
     restart: always
     networks:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3.5'
 services:
   mongodb:
-    image: mongo:latest
+    image: mongo:4.4.6-bionic
     container_name: mongodb
     restart: always
     networks:


### PR DESCRIPTION
<!-- Thanks for issuing a Pull Request (PR)! -->

### Description of PR
<!-- Describe your changes in detail -->
The timezone labels + GMT offset is calculated on the client side (removed hard-coded strings).
Resolves issue #103 

What component(s) does this PR affect?

  - [ ] Back-End (Node.js, Next.js)
  - [x] Front-End (React.js)
  - [ ] Theming (CSS, React theme)
  - [ ] Build System
  - [ ] Docs
  
  <!-- [Optional] Please elaborate on the affected component(s) here: -->
  
  Does the PR require changes on other components? If yes, please mark the components:
  
  - [ ] Back-End (Node.js, Next.js)
  - [ ] Front-End (React.js)
  - [ ] Theming (CSS, React theme)
  - [ ] Build System
  - [ ] Docs
  
  <!-- [Optional] Please elaborate on the component(s) requiring changes here: -->
  
### Related Issue
  <!-- Please make sure you have an issue associated with this Pull Request -->
  <!-- If you are suggesting a new feature or change, please discuss it in an issue first -->
  <!-- If you are fixing a bug, there should be an issue describing it with steps to reproduce -->
  <!-- Please don't forget to add `(close/fix #<issue-no>)` to the pull request title -->
  
  <!-- Please link to the issue here: -->
  Resolves #
  
### Solution
  <!-- How is this issue solved/fixed? What is the main design/logic? -->
  
### Type
  <!--- What types of changes does your code introduce? -->
  - [ ] Bug fix (non-breaking change which fixes an issue)
  - [ ] New feature (non-breaking change which adds functionality)
  - [ ] Breaking change (fix or feature that would cause existing functionality to change)
  - [ ] Docs update
  - [ ] None of the above
  
  <!-- [Optional] If none of the above applies, please elaborate here -->
  
### Checklist:
  <!-- Go over all the following points, and mark what applies. -->
  - [ ] I have read the **[contributing guide](https://github.com/FORTH-ICS-INSPIRE/artemis/blob/master/CONTRIBUTING.md)** and my code conforms to the guidelines.
  - [ ] This change requires a change in the documentation.
  - [ ] I have updated the documentation accordingly.
  >)`>>>)>
