### PR TITLE
fix: hijack time started timestamp fix

### DIFF
--- a/apps/artemis-web/utils/parsers.tsx
+++ b/apps/artemis-web/utils/parsers.tsx
@@ -350,7 +350,7 @@ function extractHijackInfoRight(hijack) {
       ),
     ],
     'Mitigation Started': [
-      hijack.mitigation_started ?? 'Never',
+      hijack.mitigation_started ? formatDate(new Date(hijack.mitigation_started), Math.abs(new Date().getTimezoneOffset() / 60)) : 'Never',
       genTooltip(
         'Mitigation Started:',
         null,

--- a/apps/artemis-web/utils/parsers.tsx
+++ b/apps/artemis-web/utils/parsers.tsx
@@ -312,7 +312,7 @@ function extractHijackInfoLeft(
 function extractHijackInfoRight(hijack) {
   const hijackInfo = {
     'Time Started': [
-      formatDate(new Date(hijack.time_started), 2),
+      formatDate(new Date(hijack.time_started), Math.abs(new Date().getTimezoneOffset() / 60)),
       genTooltip(
         'Time Started:',
         null,


### PR DESCRIPTION
<!-- Thanks for issuing a Pull Request (PR)! -->
Resolves #123 
### Description of PR
<!-- Describe your changes in detail -->

What component(s) does this PR affect?

  - [ ] Back-End (Node.js, Next.js)
  - [x] Front-End (React.js)
  - [ ] Theming (CSS, React theme)
  - [ ] Build System
  - [ ] Docs
  
  <!-- [Optional] Please elaborate on the affected component(s) here: -->
  
  Does the PR require changes on other components? If yes, please mark the components:
  
  - [ ] Back-End (Node.js, Next.js)
  - [ ] Front-End (React.js)
  - [ ] Theming (CSS, React theme)
  - [ ] Build System
  - [ ] Docs
  
  <!-- [Optional] Please elaborate on the component(s) requiring changes here: -->
  
### Related Issue
  <!-- Please make sure you have an issue associated with this Pull Request -->
  <!-- If you are suggesting a new feature or change, please discuss it in an issue first -->
  <!-- If you are fixing a bug, there should be an issue describing it with steps to reproduce -->
  <!-- Please don't forget to add `(close/fix #<issue-no>)` to the pull request title -->
  
  <!-- Please link to the issue here: -->
  Resolves #
  
### Solution
  <!-- How is this issue solved/fixed? What is the main design/logic? -->
  
### Type
  <!--- What types of changes does your code introduce? -->
  - [ ] Bug fix (non-breaking change which fixes an issue)
  - [ ] New feature (non-breaking change which adds functionality)
  - [ ] Breaking change (fix or feature that would cause existing functionality to change)
  - [ ] Docs update
  - [ ] None of the above
  
  <!-- [Optional] If none of the above applies, please elaborate here -->
  
### Checklist:
  <!-- Go over all the following points, and mark what applies. -->
  - [ ] I have read the **[contributing guide](https://github.com/FORTH-ICS-INSPIRE/artemis/blob/master/CONTRIBUTING.md)** and my code conforms to the guidelines.
  - [ ] This change requires a change in the documentation.
  - [ ] I have updated the documentation accordingly.
  >)`>>>)>
