### PR TITLE
chore: bump ldapauth-fork to 5.0.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -128,6 +128,9 @@
     "url-loader": "^4.1.1",
     "whatwg-fetch": "^3.6.2"
   },
+  "resolutions": {
+    "ldapauth-fork": "^5.0.2"
+  },
   "husky": {
     "hooks": {
       "pre-commit": "yarn run format && yarn run lint",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3009,10 +3009,10 @@
   dependencies:
     "@types/node" "*"
 
-"@types/ldapjs@^1.0.9":
-  version "1.0.11"
-  resolved "https://registry.yarnpkg.com/@types/ldapjs/-/ldapjs-1.0.11.tgz#34077176af2b06186bd54e4a38ceb6e852387fa4"
-  integrity sha512-O4D1frY6xy2mQr5WouNPeltMe5EHdmU4FxbLDC6TMDX5HXOuafusGu+7Y9WAoqBaYHZ5hcFa7jfkpggyexfeXQ==
+"@types/ldapjs@^2.2.2":
+  version "2.2.2"
+  resolved "https://registry.yarnpkg.com/@types/ldapjs/-/ldapjs-2.2.2.tgz#cf79510d8dc34e5579442c2743f8a228427eb99c"
+  integrity sha512-U5HdnwIZ5uZa+f3usxdqgyfNmOROxOxXvQdQtsu6sKo8fte5vej9br2csHxPvXreAbAO1bs8/rdEzvCLpi67nQ==
   dependencies:
     "@types/node" "*"
 
@@ -9347,12 +9347,12 @@ ldap-filter@^0.3.3:
   dependencies:
     assert-plus "^1.0.0"
 
-ldapauth-fork@^5.0.1:
-  version "5.0.1"
-  resolved "https://registry.yarnpkg.com/ldapauth-fork/-/ldapauth-fork-5.0.1.tgz#18779a9c30371c5bbea02e3b6aaadb60819ad29c"
-  integrity sha512-EdELQz8zgPruqV2y88PAuAiZCgTaMjex/kEA2PIcOlPYFt75C9QFt5HGZKVQo8Sf/3Mwnr1AtiThHKcq+pRtEg==
+ldapauth-fork@^5.0.1, ldapauth-fork@^5.0.2:
+  version "5.0.2"
+  resolved "https://registry.yarnpkg.com/ldapauth-fork/-/ldapauth-fork-5.0.2.tgz#abe6a99eac578b7730e1331254643d78dffae6fa"
+  integrity sha512-fWrrBwJ162rzQIIqfPsfCHy/861kEalQNIu16gmwOMr5cmdfjNkw7XfTlzCTJHybnFg9oW9WaX4DGXa0xiGPmA==
   dependencies:
-    "@types/ldapjs" "^1.0.9"
+    "@types/ldapjs" "^2.2.2"
     bcryptjs "^2.4.0"
     ldapjs "^2.2.1"
     lru-cache "^6.0.0"


### PR DESCRIPTION
Fixes #154

<!-- Thanks for issuing a Pull Request (PR)! -->

### Description of PR
<!-- Describe your changes in detail -->

What component(s) does this PR affect?

  - [ ] Back-End (Node.js, Next.js)
  - [x] Front-End (React.js)
  - [ ] Theming (CSS, React theme)
  - [ ] Build System
  - [ ] Docs
  
  <!-- [Optional] Please elaborate on the affected component(s) here: -->
  
  Does the PR require changes on other components? If yes, please mark the components:
  
  - [ ] Back-End (Node.js, Next.js)
  - [ ] Front-End (React.js)
  - [ ] Theming (CSS, React theme)
  - [ ] Build System
  - [ ] Docs
  
  <!-- [Optional] Please elaborate on the component(s) requiring changes here: -->
  
### Related Issue
  <!-- Please make sure you have an issue associated with this Pull Request -->
  <!-- If you are suggesting a new feature or change, please discuss it in an issue first -->
  <!-- If you are fixing a bug, there should be an issue describing it with steps to reproduce -->
  <!-- Please don't forget to add `(close/fix #<issue-no>)` to the pull request title -->
  
  <!-- Please link to the issue here: -->
  Resolves #154
  
### Solution
  <!-- How is this issue solved/fixed? What is the main design/logic? -->
  
### Type
  <!--- What types of changes does your code introduce? -->
  - [x] Bug fix (non-breaking change which fixes an issue)
  - [ ] New feature (non-breaking change which adds functionality)
  - [ ] Breaking change (fix or feature that would cause existing functionality to change)
  - [ ] Docs update
  - [ ] None of the above
  
  <!-- [Optional] If none of the above applies, please elaborate here -->
  
### Checklist:
  <!-- Go over all the following points, and mark what applies. -->
  - [x] I have read the **[contributing guide](https://github.com/FORTH-ICS-INSPIRE/artemis/blob/master/CONTRIBUTING.md)** and my code conforms to the guidelines.
  - [ ] This change requires a change in the documentation.
  - [ ] I have updated the documentation accordingly.