### PR TITLE
fix: set default value to select menu

### DIFF
--- a/apps/artemis-web/components/hijack-table/hijack-table.tsx
+++ b/apps/artemis-web/components/hijack-table/hijack-table.tsx
@@ -489,7 +489,6 @@ const HijackTableComponent = (props) => {
     const { hijackState, setHijackState, selectState, setSelectState } = props;
 
     const selectRef = React.createRef<HTMLSelectElement>();
-
     return (
       <>
         <button
@@ -522,6 +521,7 @@ const HijackTableComponent = (props) => {
             }}
             className="form-control form-control-sm-auto"
             id="action_selection"
+            value={selectState}
           >
             <option value="hijack_action_resolve">Mark as Resolved</option>
             <option value="hijack_action_ignore">Mark as Ignored</option>
@@ -544,6 +544,7 @@ const HijackTableComponent = (props) => {
             }}
             className="form-control form-control-sm-auto"
             id="action_selection"
+            value={selectState}
           >
             <option value="hijack_action_acknowledge">
               Mark as Acknowledged


### PR DESCRIPTION
<!-- Thanks for issuing a Pull Request (PR)! -->

### Description of PR
<!-- Describe your changes in detail -->
Resolves #167 

What component(s) does this PR affect?

  - [ ] Back-End (Node.js, Next.js)
  - [x] Front-End (React.js)
  - [ ] Theming (CSS, React theme)
  - [ ] Build System
  - [ ] Docs
  
  <!-- [Optional] Please elaborate on the affected component(s) here: -->
  
  Does the PR require changes on other components? If yes, please mark the components:
  
  - [ ] Back-End (Node.js, Next.js)
  - [ ] Front-End (React.js)
  - [ ] Theming (CSS, React theme)
  - [ ] Build System
  - [ ] Docs
  
  <!-- [Optional] Please elaborate on the component(s) requiring changes here: -->
  
### Related Issue
  <!-- Please make sure you have an issue associated with this Pull Request -->
  <!-- If you are suggesting a new feature or change, please discuss it in an issue first -->
  <!-- If you are fixing a bug, there should be an issue describing it with steps to reproduce -->
  <!-- Please don't forget to add `(close/fix #<issue-no>)` to the pull request title -->
  
  <!-- Please link to the issue here: -->
  Resolves #
  
### Solution
  <!-- How is this issue solved/fixed? What is the main design/logic? -->
  
### Type
  <!--- What types of changes does your code introduce? -->
  - [ ] Bug fix (non-breaking change which fixes an issue)
  - [ ] New feature (non-breaking change which adds functionality)
  - [ ] Breaking change (fix or feature that would cause existing functionality to change)
  - [ ] Docs update
  - [ ] None of the above
  
  <!-- [Optional] If none of the above applies, please elaborate here -->
  
### Checklist:
  <!-- Go over all the following points, and mark what applies. -->
  - [ ] I have read the **[contributing guide](https://github.com/FORTH-ICS-INSPIRE/artemis/blob/master/CONTRIBUTING.md)** and my code conforms to the guidelines.
  - [ ] This change requires a change in the documentation.
  - [ ] I have updated the documentation accordingly.
  >)`>>>)>
